### PR TITLE
At least on my version of Ubuntu (Natty Narwhal) the tesseract library is

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
       </li>
       <li>
         (Optional) Install <a href="http://code.google.com/p/tesseract-ocr/">Tesseract</a>:<br />
-        <tt>[aptitude | port] install tesseract</tt><br />
+        <tt>[aptitude install tesseract-ocr | port install tesseract]</tt><br />
         Without Tesseract installed, you'll still be able to extract text from
         documents, but you won't be able to automatically OCR them.
       </li>


### PR DESCRIPTION
At least on my version of Ubuntu (Natty Narwhal) the tesseract library is labeled as 'tesseract-ocr'
