### PR TITLE
File --mime-type option unrecognized on CentOS

### DIFF
--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -65,7 +65,7 @@ module Docsplit
       basename = File.basename(doc, ext)
       escaped_doc, escaped_out, escaped_basename = [doc, out, basename].map(&ESCAPE)
 
-      if GM_FORMATS.include?(`file -b --mime-type #{doc}`.strip)
+      if GM_FORMATS.include?(`file -b --mime #{doc}`.strip.split(/[:;]\s+/)[0])
         `gm convert #{escaped_doc} #{escaped_out}/#{escaped_basename}.pdf`
       else
         options = "-jar #{ROOT}/vendor/jodconverter/jodconverter-core-3.0-beta-3.jar -r #{ROOT}/vendor/conf/document-formats.js"


### PR DESCRIPTION
I've found a bug in my patch, and I'd like to submit a fix. :)

CentOS, and most likely other distros, do not have the --mime-type option for `file`. Here is the error: 'file: unrecognized option --mime-type'. The --mime option is more standard.

```$ uname -o
GNU/Linux
$ file -b --mime text.txt 
text/plain; charset=us-ascii
$ file -b --mime-type text.txt 
file: unrecognized option`--mime-type'
Usage: file [-bcikLhnNsvz] [-f namefile] [-F separator] [-m magicfiles] file...
       file -C -m magicfiles
Try `file --help' for more information.

``````

```% uname -a
Darwin Greenwood.local 11.0.1 Darwin Kernel Version 11.0.1: Thu Jul 28 02:01:39 PDT 2011; root:xnu-1699.23.4~1/RELEASE_X86_64 x86_64
% file -b --mime 9931267.txt 
text/html; charset=utf-8
``````

```$ uname -a
Linux devdb 2.6.38-11-generic-pae #50-Ubuntu SMP Mon Sep 12 22:21:04 UTC 2011 i686 i686 i386 GNU/Linux
$ file -b --mime text.txt 
text/plain; charset=us-ascii

```
```
