### PR TITLE
qpdf decryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*~
 *.gem
 .DS_Store

--- a/lib/docsplit/page_extractor.rb
+++ b/lib/docsplit/page_extractor.rb
@@ -12,13 +12,32 @@ module Docsplit
         page_path = File.join(@output, "#{pdf_name}_%d.pdf")
         FileUtils.mkdir_p @output unless File.exists?(@output)
         cmd = "pdftk #{ESCAPE[pdf]} burst output #{ESCAPE[page_path]} 2>&1"
-        result = `#{cmd}`.chomp
+        begin
+            result = `#{cmd}`.chomp
+            raise EncryptedPDF, pdf if result.include? "OWNER PASSWORD REQUIRED"
+            raise ExtractionFailed, result if $? != 0
+        # Catch when PDF is encrypted
+        rescue EncryptedPDF => pdf
+           # And if qpdf is installed ...
+           if DEPENDENCIES[:qpdf] and not opts[:retry]
+              # Decrypt it
+              temppath = Docsplit.decrypt_pdf(pdf)
+              # Signal a retry
+              opts[:retry] = true
+              # Try again, recursively
+              extract([temppath], opts)
+              # Forget all about retry
+              opts[:retry] = false
+              # Delete temp path
+              FileUtils.rm(temppath)
+              # Move on to the next guy in the loop
+              next
+           end
+        end
         FileUtils.rm('doc_data.txt') if File.exists?('doc_data.txt')
-        raise ExtractionFailed, result if $? != 0
         result
       end
     end
-
 
     private
 


### PR DESCRIPTION
In the commit below, I sketched out an idea for how qpdf's decryption could be integrated and "just work." This is a response to Issue #28. 

The recursive loop is ugly and this is the first Ruby code I've ever written, so I'm sure there's 100 things wrong with it. I don't expect you to accept it or anything, but if you had feedback for how I could better approach things, or just flat out tell me what sucks, I'd appreciate it.

It worked for me passing in a singleton or list or locked docs. I ran something like this:

<pre><code>require 'lib/docsplit'

Docsplit.extract_pages(['locked1.pdf', 'locked1.pdf'])</code></pre>
