### PR TITLE
Ignore non-ascii chars in extracted PDF info.

### DIFF
--- a/lib/docsplit/info_extractor.rb
+++ b/lib/docsplit/info_extractor.rb
@@ -1,3 +1,5 @@
+require 'iconv'
+
 module Docsplit
 
   # Delegates to **pdfinfo** in order to extract information about a PDF file.
@@ -19,7 +21,8 @@ module Docsplit
     def extract(key, pdfs, opts)
       pdf = [pdfs].flatten.first
       cmd = "pdfinfo #{ESCAPE[pdf]} 2>&1"
-      result = `#{cmd}`.chomp
+      # Remove non-ASCII characters as the matcher chokes on them
+      result = Iconv.conv('ASCII//IGNORE', 'UTF8', `#{cmd}`.chomp)
       raise ExtractionFailed, result if $? != 0
       match = result.match(MATCHERS[key])
       answer = match && match[1]


### PR DESCRIPTION
I was seeing a few of these errors.
# <ArgumentError: invalid byte sequence in US-ASCII>

/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/info_extractor.rb:24:in `match'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/info_extractor.rb:24:in`match'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/info_extractor.rb:24:in `extract'
(eval):3:in`extract_length'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:34:in `convert'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:19:in`block (3 levels) in extract'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:19:in `each'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:19:in`block (2 levels) in extract'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:18:in `each'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:18:in`each_with_index'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:18:in `block in extract'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:16:in`each'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit/image_extractor.rb:16:in `extract'
/opt/local/lib64/ruby/gems/1.9.1/gems/docsplit-0.6.3/lib/docsplit.rb:58:in`extract_images'

It turns out the problem was the metadata returned from pdfinfo  contained the restricted symbol (R) in some of the fields.

For example:
Creator:        Microsoft® Office Word 2007
Producer:       Microsoft® Office Word 2007
CreationDate:   Mon Jul 18 12:52:52 2011
ModDate:        Mon Jul 18 12:52:52 2011
Tagged:         yes
Pages:          4
Encrypted:      no
Page size:      612 x 792 pts (letter)
File size:      114279 bytes
Optimized:      no
PDF version:    1.5

After applying this patch to remove non-ascii characters from the pdfinfo output I was able to use docsplit.

Tested on Linux with ruby 1.9.1-p431 and 1.9.2-p0
