### PR TITLE
Added ability to extract all metadata at once

### DIFF
--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -87,6 +87,12 @@ module Docsplit
       end
     EOS
   end
+  
+  # Use the InfoExtractor to print out all the metadata
+  def self.extract_info(pdfs, opts={})
+    pdfs = ensure_pdfs(pdfs)
+    InfoExtractor.new.extract_all(pdfs, opts)
+  end
 
   # Utility method to clean OCR'd text with garbage characters.
   def self.clean_text(text)

--- a/lib/docsplit/command_line.rb
+++ b/lib/docsplit/command_line.rb
@@ -45,6 +45,7 @@ Options:
         when :pages   then Docsplit.extract_pages(ARGV, @options)
         when :text    then Docsplit.extract_text(ARGV, @options)
         when :pdf     then Docsplit.extract_pdf(ARGV, @options)
+        when :info    then Docsplit.extract_info(ARGV, @options).each {|metadata| puts "%s: %s" % metadata}
         else
           if METADATA_KEYS.include?(@command)
             value = Docsplit.send("extract_#{@command}", ARGV, @options)

--- a/lib/docsplit/info_extractor.rb
+++ b/lib/docsplit/info_extractor.rb
@@ -26,6 +26,25 @@ module Docsplit
       answer = answer.to_i if answer && key == :length
       answer
     end
+    
+    # Pull all supported datums from a pdf.
+    def extract_all(pdfs, opts)
+      pdf = [pdfs].flatten.first
+      cmd = "pdfinfo #{ESCAPE[pdf]} 2>&1"
+      result = `#{cmd}`.chomp
+      raise ExtractionFailed, result if $? != 0
+      
+      answers = {}
+      MATCHERS.each do |key, pattern|
+        match = result.match(pattern)
+        answer = match && match[1]
+        if answer
+          answer = answer.to_i if key == :length
+          answers[key] = answer
+        end
+      end
+      answers
+    end
 
   end
 

--- a/test/unit/test_extract_info.rb
+++ b/test/unit/test_extract_info.rb
@@ -35,5 +35,16 @@ class ExtractInfoTest < Test::Unit::TestCase
   def test_name_escaping_while_extracting_info
     assert 2 == Docsplit.extract_length('test/fixtures/PDF file with spaces \'single\' and "double quotes".pdf')
   end
+  
+  def test_extract_all
+    metadata = Docsplit.extract_info('test/fixtures/obama_arts.pdf')
+    assert metadata[:author] == "mkommareddi"
+    assert metadata[:date] == "Thu Nov 29 14:54:46 2007"
+    assert metadata[:creator] == "PScript5.dll Version 5.2"
+    assert metadata[:producer] == "Acrobat Distiller 8.1.0 (Windows)"
+    assert metadata[:title] == "Microsoft Word - Fact Sheet Arts 112907 FINAL.doc"
+    assert metadata[:length] == 2
+    assert metadata.length == 6
+  end
 
 end


### PR DESCRIPTION
I added the ability to extract all the possible metadata I could without running the extract_\* commands or pdftk multiple times for the same file. I also added tests and a pretty command_line view for all the supported metadata.
