### PR TITLE
Detect PDF files without .pdf extension using magic number

### DIFF
--- a/lib/docsplit/transparent_pdfs.rb
+++ b/lib/docsplit/transparent_pdfs.rb
@@ -11,10 +11,18 @@ module Docsplit
         ext = File.extname(doc)
         if ext.downcase == '.pdf'
           doc
-        else
-          tempdir = File.join(Dir.tmpdir, 'docsplit')
-          extract_pdf([doc], {:output => tempdir})
-          File.join(tempdir, File.basename(doc, ext) + '.pdf')
+        else 
+          #this test is nested because it's relatively expensive, no need to do it for files with pdf extensions
+          filetypeHeader = File.open(doc, 'r') { |f| f.read(4)}
+          is_pdf = (filetypeHeader =~ /\%PDF/) == 0 
+          #via http://stackoverflow.com/questions/7919674/how-to-verify-downloaded-file-format
+          if is_pdf
+            doc
+          else
+            tempdir = File.join(Dir.tmpdir, 'docsplit')
+            extract_pdf([doc], {:output => tempdir})
+            File.join(tempdir, File.basename(doc, ext) + '.pdf')
+          end
         end
       end
     end


### PR DESCRIPTION
This patch checks whether input files that do not have a .pdf extension have "%PDF" as their first four bytes. If the file has this magic number, it treats them as a PDF. The PDF standard requires that PDFs begin with that magic number, per [Adobe's PDF spec](http://wwwimages.adobe.com/www.adobe.com/content/dam/Adobe/en/devnet/pdf/pdfs/adobe_supplement_iso32000.pdf). 

Acrobat can non-standard open files that have the magic number anywhere in the first 1024 bytes (see page 108). This patch won't detect those non-standard files: I think the extra computational cost isn't worth the effort for an ever-smaller set of non-standard PDFs without a .pdf extension.

If someone had a plaintext file that began with %PDF, this patch would have docsplit treat it as a PDF. I don't think this is a serious problem: for instance, Ubuntu treats anything beginning with "%PDF-" as a PDF if it lacks a file extension.
