### PR TITLE
Various improvements

### DIFF
--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -16,7 +16,7 @@ module Docsplit
 
   OFFICE        = RUBY_PLATFORM.match(/darwin/i) ? '' : "-Doffice.home=#{office}"
 
-  METADATA_KEYS = [:author, :date, :creator, :keywords, :producer, :subject, :title, :length]
+  METADATA_KEYS = [:author, :date, :creator, :keywords, :producer, :subject, :title, :length, :dimensions]
 
   GM_FORMATS    = ["image/gif", "image/jpeg", "image/png", "image/x-ms-bmp", "image/svg+xml", "image/tiff", "image/x-portable-bitmap", "application/postscript", "image/x-portable-pixmap"]
 

--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -17,7 +17,7 @@ module Docsplit
   OFFICE        = RUBY_PLATFORM.match(/darwin/i) ? '' : "-Doffice.home=#{office}"
 
   METADATA_KEYS = [:author, :date, :creator, :keywords, :producer, :subject, :title, :length]
-  
+
   GM_FORMATS    = ["image/gif", "image/jpeg", "image/png", "image/x-ms-bmp", "image/svg+xml", "image/tiff", "image/x-portable-bitmap", "application/postscript", "image/x-portable-pixmap"]
 
   DEPENDENCIES  = {:java => false, :gm => false, :pdftotext => false, :pdftk => false, :tesseract => false}
@@ -38,6 +38,15 @@ module Docsplit
   # Raise an ExtractionFailed exception when the PDF is encrypted, or otherwise
   # broke.
   class ExtractionFailed < StandardError; end
+
+  # Allow bypassing ensure_pdfs for processing PDFs without extensions
+  def self.skip_ensure_pdfs
+    @skip_ensure_pdfs
+  end
+
+  def self.skip_ensure_pdfs=(val)
+    @skip_ensure_pdfs = val
+  end
 
   # Use the ExtractPages Java class to burst a PDF into single pages.
   def self.extract_pages(pdfs, opts={})

--- a/lib/docsplit/info_extractor.rb
+++ b/lib/docsplit/info_extractor.rb
@@ -5,14 +5,15 @@ module Docsplit
 
     # Regex matchers for different bits of information.
     MATCHERS = {
-      :author   => /^Author:\s+([^\n]+)/,
-      :date     => /^CreationDate:\s+([^\n]+)/,
-      :creator  => /^Creator:\s+([^\n]+)/,
-      :keywords => /^Keywords:\s+([^\n]+)/,
-      :producer => /^Producer:\s+([^\n]+)/,
-      :subject  => /^Subject:\s+([^\n]+)/,
-      :title    => /^Title:\s+([^\n]+)/,
-      :length   => /^Pages:\s+([^\n]+)/,
+      :author     => /^Author:\s+([^\n]+)/,
+      :date       => /^CreationDate:\s+([^\n]+)/,
+      :creator    => /^Creator:\s+([^\n]+)/,
+      :keywords   => /^Keywords:\s+([^\n]+)/,
+      :producer   => /^Producer:\s+([^\n]+)/,
+      :subject    => /^Subject:\s+([^\n]+)/,
+      :title      => /^Title:\s+([^\n]+)/,
+      :length     => /^Pages:\s+([^\n]+)/,
+      :dimensions => /^Page size:\s+(\d+)\D+(\d+)/,
     }
 
     # Pull out a single datum from a pdf.
@@ -24,6 +25,7 @@ module Docsplit
       match = result.match(MATCHERS[key])
       answer = match && match[1]
       answer = answer.to_i if answer && key == :length
+      answer = [match[1].to_i, match[2].to_i] if match[1] && match[2] && key == :dimensions
       answer
     end
 

--- a/lib/docsplit/transparent_pdfs.rb
+++ b/lib/docsplit/transparent_pdfs.rb
@@ -9,7 +9,7 @@ module Docsplit
     def ensure_pdfs(docs)
       [docs].flatten.map do |doc|
         ext = File.extname(doc)
-        if ext.downcase == '.pdf'
+        if skip_ensure_pdfs || ext.downcase == '.pdf'
           doc
         else
           tempdir = File.join(Dir.tmpdir, 'docsplit')


### PR DESCRIPTION
1) Allow bypassing ensure_pdfs for processing PDFs without extensions

We store files without extensions, which the ensure_pdfs doesn't appreciate. This works around the issue for me. I'm not sure if there's a better alternative, though...? 

2) Add extract_dimensions using pdfinfo to return an array of [width, height]

If these look acceptable, I'd happily work up some tests and/or documentation. Thank you!
