### PR TITLE
Uses crop box on PDF image creation. Fixes #58

### DIFF
--- a/lib/docsplit/image_extractor.rb
+++ b/lib/docsplit/image_extractor.rb
@@ -42,7 +42,7 @@ module Docsplit
       else
         page_list(pages).each do |page|
           out_file  = ESCAPE[File.join(directory, "#{basename}_#{page}.#{format}")]
-          cmd = "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 gm convert +adjoin #{common} #{escaped_pdf}[#{page - 1}] #{out_file} 2>&1".chomp
+          cmd = "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 gm convert +adjoin -define pdf:use-cropbox=true #{common} #{escaped_pdf}[#{page - 1}] #{out_file} 2>&1".chomp
           result = `#{cmd}`.chomp
           raise ExtractionFailed, result if $? != 0
         end


### PR DESCRIPTION
Certain PDF formats leave whitespace surrounding the image extraction when GS uses the MediaBox size to extract the image of a page. This fix forces GM and therefore GS to use the CropBox size. Crop box support for GM was added in [1.3.13](http://www.graphicsmagick.org/NEWS.html#december-24-2011), but there's not detrimental effects to running it against older versions. It seems to fall back to the MediaBox (the original behaviour) if no CropBox is defined
