### PR TITLE
Ghostscript is needed to use docsplit with PDF files

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,11 @@
         <tt>sudo port install poppler | brew install poppler</tt><br />
       </li>
       <li>
+        (Optional) Install <a href="http://www.ghostscript.com/">Ghostscript</a>:<br />
+        <tt>[aptitude | port | brew] install ghostscript</tt><br />
+        Ghostscript is required to convert PDF and Postscript files.
+      </li>
+      <li>
         (Optional) Install <a href="http://code.google.com/p/tesseract-ocr/">Tesseract</a>:<br />
         <tt>[aptitude | port | brew] install [tesseract | tesseract-ocr]</tt><br />
         Without Tesseract installed, you'll still be able to extract text from


### PR DESCRIPTION
The document doesn't specify that you need to install ghostscript. I suspect most Linux distributions install this by default for various Postscript/PDF rendering, but it doesn't get installed on Mac OS X. I listed it as an optional dependency, as maybe there are uses of docsplit that don't need it?

This is an "indirect" dependency: graphicsmagick is actually what uses this.

Example error message with ghostscript:

execvp failed, errno = 2 (No such file or directory)
gm convert: "gs" "-q" "-dBATCH" "-dMaxBitmap=50000000" "-dNOPAUSE" "-sDEVICE=ppmraw" "-dTextAlphaBits=4" "-dGraphicsAlphaBits=4" "-r150x150" "-dFirstPage=1" "-dLastPage=1" "-sOutputFile=/var/folders/7f/_bn7l9zs7c7d_v15pgf8yr5m0000gn/T/d20121106-64573-1o6ttz4/gmxUt13R" "--" "/var/folders/7f/_bn7l9zs7c7d_v15pgf8yr5m0000gn/T/d20121106-64573-1o6ttz4/gm3lF7D8" "-c" "quit".
gm convert: Postscript delegate failed (/var/folders/7f/_bn7l9zs7c7d_v15pgf8yr5m0000gn/T/tmpPs0VPq/509948e93e091afc3ab1e1c9/original.pdf).
