### PR TITLE
Accept non-ascii characters in pdf headers

### DIFF
--- a/lib/docsplit/info_extractor.rb
+++ b/lib/docsplit/info_extractor.rb
@@ -21,6 +21,13 @@ module Docsplit
       cmd = "pdfinfo #{ESCAPE[pdf]} 2>&1"
       result = `#{cmd}`.chomp
       raise ExtractionFailed, result if $? != 0
+      # ruby  1.8 (iconv) and 1.9 (String#encode) :
+      if String.method_defined?(:encode)
+        result.encode!('UTF-8', 'UTF-8', :invalid => :replace)
+      else
+        ic = Iconv.new('UTF-8', 'UTF-8//IGNORE')
+        result = ic.iconv(result)
+      end
       match = result.match(MATCHERS[key])
       answer = match && match[1]
       answer = answer.to_i if answer && key == :length


### PR DESCRIPTION
Previous pull requests were not working for me.  Googling led me to stack overflow
http://stackoverflow.com/a/8873922/234125

for a working solution
Update lib/docsplit/info_extractor.rb
