### PR TITLE
new libreoffice has --version

### DIFF
--- a/lib/docsplit/pdf_extractor.rb
+++ b/lib/docsplit/pdf_extractor.rb
@@ -19,7 +19,12 @@ module Docsplit
     # The first line of the help output holds the name and version number
     # of the office software to be used for extraction.
     def version_string
-      @@help ||= `#{office_executable} -h 2>&1`.split("\n").first
+      versionstr =  `#{office_executable} -h 2>&1`.split("\n").first
+        if !!versionstr.match(/[0-9]*/)
+                versionstr =  `#{office_executable} --version`.split("\n").first
+        end
+        @@help ||= versionstr
+
     end
     def libre_office?
       !!version_string.match(/^LibreOffice/)


### PR DESCRIPTION
this should match if first line didn't have a version number i.e. error like: Error: Could not find or load main class .usr.lib.libreoffice or Failed to open display which shows if running headless.
