### PR TITLE
Add another possible LibreOffice executable path

### DIFF
--- a/lib/docsplit/pdf_extractor.rb
+++ b/lib/docsplit/pdf_extractor.rb
@@ -46,6 +46,7 @@ module Docsplit
       else # probably linux/unix
         search_paths = %w(
           /usr/lib/libreoffice
+          /usr/bin/libreoffice
           /opt/libreoffice
           /usr/lib/openoffice
           /opt/openoffice.org3


### PR DESCRIPTION
This will fix situations in which LibreOffice is installed at `/usr/bin/libreoffice`.
