### PR TITLE
Clean text without Iconv to support Ruby 2.0

### DIFF
--- a/lib/docsplit/text_cleaner.rb
+++ b/lib/docsplit/text_cleaner.rb
@@ -35,8 +35,13 @@ module Docsplit
     # For the time being, `clean` uses the regular StringScanner, and not the
     # multibyte-aware version, coercing to ASCII first.
     def clean(text)
-      require 'iconv' unless defined?(Iconv)
-      text    = Iconv.iconv('ascii//translit//ignore', 'utf-8', text).first
+      if String.method_defined?(:encode)
+        text.encode!('ascii', :invalid => :replace, :undef => :replace, :replace => '?')
+      else
+        require 'iconv' unless defined?(Iconv)
+        text = Iconv.iconv('ascii//translit//ignore', 'utf-8', text).first
+      end
+
       scanner = StringScanner.new(text)
       cleaned = []
       spaced  = false


### PR DESCRIPTION
The clean method in text_cleaner.rb requires Iconv, which was deprecated in Ruby 1.9 and removed in 2.0.

This patch follows the pattern used in info_extractor.rb, which is to use String#encode if it is defined.
