### PR TITLE
Default 64-bit installation paths

### DIFF
--- a/lib/docsplit/pdf_extractor.rb
+++ b/lib/docsplit/pdf_extractor.rb
@@ -46,8 +46,10 @@ module Docsplit
       else # probably linux/unix
         search_paths = %w(
           /usr/lib/libreoffice
+          /usr/lib64/libreoffice
           /opt/libreoffice
           /usr/lib/openoffice
+          /usr/lib64/openoffice.org3
           /opt/openoffice.org3
         )
       end


### PR DESCRIPTION
docsplit does not recognize 64bit installation paths by default on Linux/Unix operating systems. The accompanied pull request adds those paths:
- /usr/lib64/libreoffice
- /usr/lib64/openoffice.org3

Thanks for keeping up the great work.

Cheers!
