### PR TITLE
Add /usr/lib64 to office_search_paths

### DIFF
--- a/lib/docsplit/pdf_extractor.rb
+++ b/lib/docsplit/pdf_extractor.rb
@@ -46,8 +46,10 @@ module Docsplit
       else # probably linux/unix
         search_paths = %w(
           /usr/lib/libreoffice
+          /usr/lib64/libreoffice
           /opt/libreoffice
           /usr/lib/openoffice
+          /usr/lib64/openoffice
           /opt/openoffice.org3
         )
       end


### PR DESCRIPTION
As it's used by Oracle RHEL 6.3 and probably by RHEL in general.
