### PR TITLE
Extract image or pdf on windows platform bugfix

### DIFF
--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -7,7 +7,10 @@ module Docsplit
 
   VERSION       = '0.7.2' # Keep in sync with gemspec.
 
-  ESCAPE        = lambda {|x| Shellwords.shellescape(x) }
+  HOST_OS = (defined?("RbConfig") ? RbConfig : Config)::CONFIG['host_os']
+  IS_WIN = !!HOST_OS.match(/mswin|msys|mingw|cygwin|bccwin|wince|emc/i)
+  
+  ESCAPE        = IS_WIN ? lambda {|x| "\"#{x}\"" } : lambda {|x| Shellwords.shellescape(x) }
 
   ROOT          = File.expand_path(File.dirname(__FILE__) + '/..')
   ESCAPED_ROOT  = ESCAPE[ROOT]

--- a/lib/docsplit/image_extractor.rb
+++ b/lib/docsplit/image_extractor.rb
@@ -8,12 +8,6 @@ module Docsplit
     DEFAULT_FORMAT  = :png
     DEFAULT_DENSITY = '150'
 
-    # Helper function to determine the OS
-    HOST_OS = (defined?("RbConfig") ? RbConfig : Config)::CONFIG['host_os']
-    def windows?
-      !!HOST_OS.match(/mswin|msys|mingw|cygwin|bccwin|wince|emc/i)
-    end
-
     # Extract a list of PDFs as rasterized page images, according to the
     # configuration in options.
     def extract(pdfs, options)
@@ -45,7 +39,7 @@ module Docsplit
         # Only copy image files, skip other files such as Thumbs.db under windows platform
         imageFiles = File.join(directory_for(previous), '*.' + format)
         FileUtils.cp(Dir.glob(imageFiles), directory)
-        if windows?
+        if IS_WIN
           cmd = "set MAGICK_TMPDIR=#{tempdir} & set OMP_NUM_THREADS=2 & gm mogrify #{common} -unsharp 0x0.5+0.75 \"#{directory}/*.#{format}\" 2>&1".chomp
         else
           cmd = "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 gm mogrify #{common} -unsharp 0x0.5+0.75 \"#{directory}/*.#{format}\" 2>&1".chomp
@@ -54,7 +48,7 @@ module Docsplit
         raise ExtractionFailed, result if $? != 0
       else
         page_list(pages).each do |page|
-          if windows?
+          if IS_WIN
             out_file  = File.join(directory, "#{basename}_#{page}.#{format}")
             cmd = "set MAGICK_TMPDIR=#{tempdir} & set OMP_NUM_THREADS=2 & gm convert +adjoin -define pdf:use-cropbox=true #{common} #{escaped_pdf}[#{page - 1}] \"#{out_file}\" 2>&1".chomp
           else

--- a/lib/docsplit/pdf_extractor.rb
+++ b/lib/docsplit/pdf_extractor.rb
@@ -7,7 +7,7 @@ module Docsplit
     # Provide a set of helper functions to determine the OS.
     HOST_OS = (defined?("RbConfig") ? RbConfig : Config)::CONFIG['host_os']
     def windows?
-      !!HOST_OS.match(/mswin|msys|mingw|cygwin|bccwin|wince|emc/i)
+      IS_WIN
     end
     def osx?
       !!HOST_OS.match(/darwin/i)


### PR DESCRIPTION
Use set command to set "gm" environment variables on windows platform.
Use LibreOffice to extract pdf on windows platform bugfix.
