### PR TITLE
Enable specification of a config file, and generate hocr output if option set

### DIFF
--- a/docsplit.gemspec
+++ b/docsplit.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['build/**/*', 'lib/**/*', 'bin/*', 'vendor/**/*',
                 'docsplit.gemspec', 'LICENSE', 'README']
+
+  s.add_dependency "nokogiri"
 end

--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -79,6 +79,11 @@ module Docsplit
     TextCleaner.new.clean(text)
   end
 
+  # Utility method to clean OCR'd text in hOCR output format.
+  def self.clean_hocr(html)
+    TextCleaner.new.clean_hocr(html)
+  end
+
   private
 
   # Normalize a value in an options hash for the command line.

--- a/lib/docsplit/command_line.rb
+++ b/lib/docsplit/command_line.rb
@@ -91,6 +91,9 @@ Options:
         opts.on('--[no-]ocr', 'force OCR to be used, or disable OCR') do |o|
           @options[:ocr] = o
         end
+        opts.on('-c', '--config [FILE]', 'use the specified config file') do |c|
+          @options[:config] = c
+        end
         opts.on('--no-clean', 'disable cleaning of OCR\'d text') do |c|
           @options[:clean] = false
         end

--- a/lib/docsplit/text_extractor.rb
+++ b/lib/docsplit/text_extractor.rb
@@ -1,3 +1,5 @@
+require 'nokogiri'
+
 module Docsplit
 
   # Delegates to **pdftotext** and **tesseract** in order to extract text from
@@ -20,6 +22,10 @@ module Docsplit
     MEMORY_ARGS = '-limit memory 256MiB -limit map 512MiB'
 
     MIN_TEXT_PER_PAGE = 100 # in bytes
+
+    HOCR_SECTIONS = [ [ '.ocr_par',   "\n\n" ],
+                      [ '.ocr_line',  "\n"   ],
+                      [ '.ocrx_word', " "    ] ]
 
     def initialize
       @pages_to_ocr = []
@@ -66,16 +72,20 @@ module Docsplit
           escaped_tiff = ESCAPE[tiff]
           file = "#{base_path}_#{page}"
           run "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 gm convert -despeckle +adjoin #{MEMORY_ARGS} #{OCR_FLAGS} #{escaped_pdf}[#{page - 1}] #{escaped_tiff} 2>&1"
-          run "tesseract #{escaped_tiff} #{ESCAPE[file]} -l #{@language} 2>&1"
-          clean_text(file + '.txt') if @clean_ocr
+          run "tesseract #{escaped_tiff} #{ESCAPE[file]} -l #{@language} #{@config} 2>&1"
+          run "cp #{escaped_tiff} #{base_path}_#{page}.tif" if @gen_hocr
+          clean_ocr(file) if @clean_ocr
+          generate_text_and_annotate(file) if @gen_hocr
           FileUtils.remove_entry_secure tiff
         end
       else
         tiff = "#{tempdir}/#{@pdf_name}.tif"
         escaped_tiff = ESCAPE[tiff]
         run "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 gm convert -despeckle #{MEMORY_ARGS} #{OCR_FLAGS} #{escaped_pdf} #{escaped_tiff} 2>&1"
-        run "tesseract #{escaped_tiff} #{base_path} -l #{@language} 2>&1"
-        clean_text(base_path + '.txt') if @clean_ocr
+        run "tesseract #{escaped_tiff} #{base_path} -l #{@language} #{@config} 2>&1"
+        run "cp #{escaped_tiff} #{base_path}.tif" if @gen_hocr
+        clean_ocr(base_path) if @clean_ocr
+        generate_text_and_annotate(base_path) if @gen_hocr
       end
     ensure
       FileUtils.remove_entry_secure tempdir if File.exists?(tempdir)
@@ -84,13 +94,67 @@ module Docsplit
 
     private
 
-    def clean_text(file)
-      File.open(file, 'r+') do |f|
-        text = f.read
+    def clean_ocr(basename)
+      ext = @gen_hocr ? "html" : "txt"
+      File.open(basename + ".#{ext}", 'r+') do |f|
+        content = f.read
         f.truncate(0)
         f.rewind
-        f.write(Docsplit.clean_text(text))
+        meth = @gen_hocr ? "hocr" : "text"
+        f.write(Docsplit.send("clean_#{meth}".to_sym, content))
       end
+    end
+
+    # When generating hOCR output, tesseract doesn't generate text output.
+    # This method will generate the text output, and also add the corresponding
+    # character position of the words back into the hOCR file as HTML data
+    # attributes.
+    def generate_text_and_annotate(basename)
+      File.open(basename + '.txt', 'w') do |output|
+        File.open(basename + '.html', 'r+') do |input|
+          xml = Nokogiri::XML(input.read)
+          generate_text_position(xml) do |text, pos, elt|
+            # Write the output text file
+            output.write(text)
+
+            # Annotate the hOCR element we are given
+            if elt
+              elt['data-start'] = pos
+              elt['data-stop' ] = pos + text.size
+            end
+          end
+          input.truncate(0)
+          input.rewind
+          input.write(xml.to_xml)
+        end
+      end
+    end
+
+    def generate_text_position(root, index=0, pos=0, &block)
+      raise RuntimeError, "bad section list" if index >= HOCR_SECTIONS.size
+      # Select the sections we want at this level
+      sections = root.css(HOCR_SECTIONS[index][0])
+      sections.each do |section|
+        if index < HOCR_SECTIONS.size - 1
+          # It is not the base section, so recurse.
+          pos = generate_text_position(section, index + 1, pos, &block)
+        else
+          # It is the base section (a word), so emit the
+          # text and the xml element so the caller can
+          # annotate.
+          block.call(section.text, pos, section) if block
+          pos += section.text.size
+        end
+
+        # We 'join' the sections with the specified separator.
+        # Emit the section join text, but without the xml
+        # element, since this is just generate text.
+        if section != sections.last
+          block.call(HOCR_SECTIONS[index][1], pos, nil) if block
+          pos += HOCR_SECTIONS[index][1].size
+        end
+      end
+      pos
     end
 
     # Run an external process and raise an exception if it fails.
@@ -123,6 +187,17 @@ module Docsplit
       @forbid_ocr = options[:ocr] == false
       @clean_ocr  = !(options[:clean] == false)
       @language   = options[:language] || 'eng'
+      @gen_hocr   = check_tesseract_config(options[:config])
+      @config     = options[:config] || ''
+    end
+
+    def check_tesseract_config(config)
+      return false unless config
+      hocr_configs = File.open(config, 'r').grep(/tessedit_create_hocr/)
+      if hocr_configs.size > 0
+        return hocr_configs.last.split[1] != "0"
+      end
+      false
     end
 
   end


### PR DESCRIPTION
Guys,

Sorry it took so long to get to this, but I've opened this as a new pull request as it is substantially different from the prior one (#81). Please note the most important thing - this change adds a dependency on nokogiri.

First, I took the suggestion to make the command line option one to set a config file. If a config file is set, we look for the variable that enables hocr generation in the file itself. One thing to note is that tesseract allows you to use "+[config]" and it will look for the config file in a well-known location. I decided to just require the full path to be explicit when this option is specified, to avoid install issues.

When hocr generation is on, tesseract appears to only produce html output, not text. So, I've added some routines to generate a text file as well. Additionally, the original hocr output is annotated so that the word tags have two new data attributes set, "data-start" and "data-stop," which are the character start / stop positions of that word.

Lastly, note that the cleaning is a little simplified. I run the text from the xml node through the method that checks for a garbage word, but I didn't do anything fancy looking for too much whitespace. I figured this was good enough for now.
