### PR TITLE
Check if file is PDF by magic number. Closes #98

### DIFF
--- a/lib/docsplit/transparent_pdfs.rb
+++ b/lib/docsplit/transparent_pdfs.rb
@@ -9,7 +9,7 @@ module Docsplit
     def ensure_pdfs(docs)
       [docs].flatten.map do |doc|
         ext = File.extname(doc)
-        if ext.downcase == '.pdf'
+        if ext.downcase == '.pdf' || File.open(doc, &:readline) =~ /\A\%PDF-\d+(\.\d+)?$/
           doc
         else
           tempdir = File.join(Dir.tmpdir, 'docsplit')


### PR DESCRIPTION
It only reads the first line of the file and compares it with a regex.

According to the [PDF reference](http://wwwimages.adobe.com/www.adobe.com/content/dam/Adobe/en/devnet/pdf/pdfs/pdf_reference_1-7.pdf) (page 92) the first line shall contain any of this strings:

```
%PDF−1.0 
%PDF−1.1 
%PDF−1.2 
%PDF−1.3 
%PDF−1.4 
%PDF−1.5 
%PDF−1.6
%PDF−1.7
...
```

Related to #48, #50 (`.skip_ensure_pdfs` should be obsolete) and #98
