### PR TITLE
Add office search path to check vendor folder for use with Heroku and libreoffice buildpack

### DIFF
--- a/lib/docsplit/pdf_extractor.rb
+++ b/lib/docsplit/pdf_extractor.rb
@@ -52,6 +52,7 @@ module Docsplit
           /Applications/OpenOffice.org.app/Contents
         )
       else # probably linux/unix
+        # heroku libreoffice buildpack: https://github.com/rishihahs/heroku-buildpack-libreoffice
         search_paths = %w(
           /usr/lib/libreoffice
           /usr/lib64/libreoffice
@@ -59,6 +60,7 @@ module Docsplit
           /usr/lib/openoffice
           /usr/lib64/openoffice
           /opt/openoffice.org3
+          /app/vendor/libreoffice
         )
       end
       search_paths


### PR DESCRIPTION
This checks the app/vendor folder for libreoffice, which is where Heroku installs buildpacks.
