### PR TITLE
Fix page parsing for command line usage

### DIFF
--- a/lib/docsplit/command_line.rb
+++ b/lib/docsplit/command_line.rb
@@ -76,8 +76,8 @@ Options:
         opts.on('-o', '--output [DIR]', 'set the directory for all output') do |d|
           @options[:output] = d
         end
-        opts.on('-p', '--pages [PAGES]', "extract specific pages (eg: 5-10)") do |p|
-          @options[:pages] = p
+        opts.on('-p', '--pages [PAGES]', "extract specific pages (eg: 5-10 or 1,3,5)") do |p|
+          @options[:pages] = self.class.format_page_param(p)
         end
         opts.on('-s', '--size [SIZE]', 'set a fixed size (eg: 50x75)') do |s|
           @options[:size] = s.split(',')
@@ -118,6 +118,19 @@ Options:
         puts e.message
         exit(1)
       end
+    end
+
+    def self.format_page_param(pages_arg)
+      numbers_and_ranges = pages_arg.to_s.scan(/[\d\-]+/)
+      output = numbers_and_ranges.collect {|page_arg|
+        if page_arg.include?("-")
+          Range.new(*page_arg.split("-")).to_a
+        else
+          page_arg
+        end
+      }
+
+      output.flatten.uniq.map(&:to_i).sort
     end
 
   end

--- a/test/unit/test_command_line.rb
+++ b/test/unit/test_command_line.rb
@@ -1,0 +1,25 @@
+here = File.expand_path(File.dirname(__FILE__))
+require File.join(here, '..', 'test_helper')
+require "#{Docsplit::ROOT}/lib/docsplit/command_line"
+
+class ConvertToPdfTest < Minitest::Test
+
+  def test_page_cli_parsing
+    input = "1,3-6,9,12,2,3"
+    output = Docsplit::CommandLine.format_page_param(input)
+    assert_equal [1,2,3,4,5,6,9,12], output
+
+    input = "3"
+    output = Docsplit::CommandLine.format_page_param(input)
+    assert_equal [3], output
+
+    input = "3-6"
+    output = Docsplit::CommandLine.format_page_param(input)
+    assert_equal [3, 4, 5, 6], output
+
+    input = "2,4,6,8"
+    output = Docsplit::CommandLine.format_page_param(input)
+    assert_equal [2, 4, 6, 8], output
+  end
+
+end


### PR DESCRIPTION
This fixes the `--page` argument to work as described in the
documentation when using docsplit from the command line. Users can now
specify page ranges `5-15`, comma separated lists `1,5,7`, single pages
`3` or combinations of these e.g. `3-5,7,8,12-15`

The options parser was previously passing through a String where an
Array was expected internally. This was not an issue when using the gem directly
from Ruby, only when using the command line.

This includes a command_line unit test to exercise the new page number parser.