### PR TITLE
update pdftk installer URL for Mac

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
         (Optional) Install <a href="http://www.accesspdf.com/pdftk/">pdftk</a>.
         On Linux, use <b>aptitude</b>, <b>apt-get</b> or <b>yum</b>:<br />
         <tt>aptitude install pdftk</tt><br />
-        On the Mac, you can <a href="http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/">download a recent installer</a> for the binary.
+        On the Mac, you can <a href="https://www.pdflabs.com/tools/pdftk-server/">download a recent installer</a> for the binary.
         Without <b>pdftk</b> installed, you can use Docsplit, but won't be able
         to split apart a multi-page PDF into single-page PDFs.
       </li>


### PR DESCRIPTION
The page https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/ no longer seems to have any Mac info.